### PR TITLE
Fixing the bug #5: _tkinter.TclError: bitmap "pyidelogo.ico" not defined

### DIFF
--- a/PyIDE/Main.py
+++ b/PyIDE/Main.py
@@ -191,7 +191,10 @@ class PyIDE:
         self.codeEditor = Text(self.root, undo=1, tabs=1, yscrollcommand=self.scroll.set, font=35)
         self.frame = Frame(self.root, bg="grey")
         self.__UpdateTitle()
-        self.root.iconbitmap('pyidelogo.ico')
+        try:
+            self.root.iconbitmap('pyidelogo.ico')
+        except:
+            pass
         # Configure the menus
         self.ConfigureMenus()
         # Package all the controls / components


### PR DESCRIPTION
In my case, Ubuntu 22.04.1 LTS, Python 3.10.4, the command iconbitmap('pyidelogo.ico') failed with this error:
**__tkinter.TclError: bitmap "pyidelogo.ico" not defined_**
I solved this problem by putting the command in a try-except block.